### PR TITLE
Just return the api response from delete

### DIFF
--- a/serverdensity/wrapper/crud.py
+++ b/serverdensity/wrapper/crud.py
@@ -14,7 +14,7 @@ class CRUD(object):
     def delete(self, _id=None, **kwargs):
         if not _id:
             _id = self._id
-        return self.__class__(self.api.delete(url=self.PATHS['delete'].format(_id), **kwargs))
+        return self.api.delete(url=self.PATHS['delete'].format(_id), **kwargs)
 
     def list(self, **kwargs):
         result = self.api.get(url=self.PATHS['list'], **kwargs)

--- a/serverdensity/wrapper/schema/alerts.json
+++ b/serverdensity/wrapper/schema/alerts.json
@@ -37,7 +37,7 @@
                 "properties": {
                     "type": {
                         "type": "string",
-                        "enum": ["user", "pagerduty", "webhook","hipchat"]
+                        "enum": ["user", "pagerduty", "webhook","hipchat","slack"]
                     },
                     "id": {
                         "type": "string"


### PR DESCRIPTION
Delete raises since we don't have the required attributes from the api response to create an object.